### PR TITLE
Set the defaults in the application env

### DIFF
--- a/lib/api.ex
+++ b/lib/api.ex
@@ -9,7 +9,7 @@ defmodule Ngrok.Api do
 
   @spec first_tunnel_settings() :: error | successful_parse
   def first_tunnel_settings do
-    with api_url = Application.get_env(:ex_ngrok, :api_url, "http://localhost:4040/api/tunnels"),
+    with api_url = Application.get_env(:ex_ngrok, :api_url),
       {:ok, body} <- get(api_url),
       {:ok, parsed} <- parse(body) do
       first_tunnel(parsed)

--- a/lib/executable.ex
+++ b/lib/executable.ex
@@ -19,10 +19,10 @@ defmodule Ngrok.Executable do
   @spec ngrok :: String.t
   defp ngrok do
     arguments = [
-      Application.get_env(:ex_ngrok, :executable, "ngrok"),
-      Application.get_env(:ex_ngrok, :protocol, "http"),
-      Application.get_env(:ex_ngrok, :port, "4000"),
-      Application.get_env(:ex_ngrok, :options, ""),
+      Application.get_env(:ex_ngrok, :executable),
+      Application.get_env(:ex_ngrok, :protocol),
+      Application.get_env(:ex_ngrok, :port),
+      Application.get_env(:ex_ngrok, :options),
     ]
     Enum.join(arguments, " ")
   end

--- a/mix.exs
+++ b/mix.exs
@@ -15,6 +15,13 @@ defmodule Ngrok.Mixfile do
 
   def application do
     [applications: [:logger, :httpoison],
+     env: [
+      api_url: "http://localhost:4040/api/tunnels",
+      executable: "ngrok",
+      protocol: "http",
+      port: "4000",
+      options: "",
+     ],
      mod: {Ngrok, []}]
   end
 

--- a/test/ex_ngrok_test.exs
+++ b/test/ex_ngrok_test.exs
@@ -11,16 +11,9 @@ defmodule NgrokTest do
 
   @custom_configuration api_url: "http://localhost:4040/api/tunnels"
   test "it stores the settings" do
-    assert_application_start_success
-  end
+    :ok = Application.start(:ex_ngrok)
 
-  test "it has valid default settings" do
-    Application.delete_env(:ex_ngrok, :api_url)
-    Application.delete_env(:ex_ngrok, :executable)
-    Application.delete_env(:ex_ngrok, :protocol)
-    Application.delete_env(:ex_ngrok, :port)
-    Application.delete_env(:ex_ngrok, :options)
-    assert_application_start_success
+    assert Ngrok.Settings.get("public_url") =~ ~r/http(s)?:\/\/(.*)\.ngrok\.io/
   end
 
   @custom_configuration api_url: "http://localhost:0"
@@ -41,10 +34,5 @@ defmodule NgrokTest do
   defp assert_application_start_error(expected_message) do
     {:error, {{:shutdown, {:failed_to_start_child, Ngrok.Settings, {%RuntimeError{message: actual_message}, _stack_trace}}}, _info}} = Application.start(:ex_ngrok)
     assert actual_message =~ expected_message
-  end
-
-  defp assert_application_start_success do
-    :ok = Application.start(:ex_ngrok)
-    assert Ngrok.Settings.get("public_url") =~ ~r/http(s)?:\/\/(.*)\.ngrok\.io/
   end
 end


### PR DESCRIPTION
After reading [this](http://elixir-lang.org/docs/stable/elixir/Application.html#module-application-environment), it appears the application env is a more appropriate location to set defauls.