### PR TITLE
Select consistent tunnel

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Ngrok.Mixfile do
 
   def project do
     [app: :ex_ngrok,
-     version: "0.2.0",
+     version: "0.2.1",
      elixir: "~> 1.3",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Ensure the tunnel returned matches the specified protocol, by comparing the protocols of all tunnels available. This is to ensure that the `http` tunnel is consistently returned versus the `https` tunnel, for example.