### PR TITLE
Allow for HTTPS protocol to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ of the following in your `config/config.exs` file:
 config :ex_ngrok,
   # The name of the Ngrok executable
   executable: "ngrok",
-  # The type of tunnel (http, tcp, or tls)
+  # The type of tunnel (http, https, tcp, or tls)
   protocol: "http",
   # The port to which Ngrok will forward requests
   port: "4000",

--- a/lib/executable.ex
+++ b/lib/executable.ex
@@ -20,10 +20,20 @@ defmodule Ngrok.Executable do
   defp ngrok do
     arguments = [
       Application.get_env(:ex_ngrok, :executable),
-      Application.get_env(:ex_ngrok, :protocol),
+      protocol(),
       Application.get_env(:ex_ngrok, :port),
       Application.get_env(:ex_ngrok, :options),
     ]
     Enum.join(arguments, " ")
+  end
+
+  @spec protocol :: String.t
+  defp protocol do
+    case Application.get_env(:ex_ngrok, :protocol) do
+      "https" ->
+        "http"
+      protocol ->
+        protocol
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Ngrok.Mixfile do
 
   def project do
     [app: :ex_ngrok,
-     version: "0.3.3",
+     version: "0.3.4",
      elixir: "~> 1.7",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
When creating an `http` tunnel with Ngrok, it also gives you a `https` tunnel. This change allows the user to specify `https` as the protocol, which will create an `http` Ngrok tunnel, but will expose the `https` URL as the `public_url`.